### PR TITLE
feat: 飴と鞭モード実装

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -71,4 +71,23 @@ class AuthController extends Controller
 
         return response()->json(['status' => 'success']);
     }
+
+    /**
+     * モード更新処理
+     * PUT /api/user/mode
+     */
+    public function updateMode(Request $request): JsonResponse
+    {
+        $request->validate([
+            'mode' => ['required', 'in:sweet,spicy'],
+        ]);
+
+        $modeValue = $request->mode === 'sweet' ? 0 : 1;
+
+        auth()->user()->update([
+            'mode' => $modeValue,
+        ]);
+
+        return response()->json(['status' => 'success']);
+    }
 }

--- a/public/js/setting.js
+++ b/public/js/setting.js
@@ -28,12 +28,32 @@ function selectMode(mode) {
 
 // モード保存
 function saveMode() {
-    try {
-        localStorage.setItem("mode", selectedMode);
-        hideError();
-    } catch (e) {
-        showError("設定の保存に失敗しました。もう一度お試しください。");
-    }
+    fetch("/api/user/mode", {
+        method: "PUT",
+        headers: {
+            "Content-Type": "application/json",
+            "X-CSRF-TOKEN": document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
+        },
+        body: JSON.stringify({ mode: selectedMode }),
+    })
+        .then(response => {
+            if (!response.ok) {
+                throw new Error("ネットワークエラー");
+            }
+            return response.json();
+        })
+        .then(data => {
+            if (data.status === "success") {
+                localStorage.setItem("mode", selectedMode);
+                hideError();
+            } else {
+                showError("設定の保存に失敗しました。もう一度お試しください。");
+            }
+        })
+        .catch(error => {
+            console.error("Error:", error);
+            showError("設定の保存に失敗しました。もう一度お試しください。");
+        });
 }
 
 // フォントサイズをCSS変数に反映

--- a/resources/views/setting.blade.php
+++ b/resources/views/setting.blade.php
@@ -186,7 +186,7 @@
                     id="mode2"
                     class="mode-btn"
                     aria-pressed="false"
-                    onclick="selectMode('strict')">
+                    onclick="selectMode('spicy')">
 
                     飴と鞭
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -36,4 +36,7 @@ Route::middleware(['web', 'auth'])->group(function () {
     // 着せ替え：所持アイテム一覧 / 装備切替
     Route::get('user/items',                       [UserItemController::class, 'index']);
     Route::put('user/items/{ownedItem}/equip',     [UserItemController::class, 'equip']);
+
+    // ユーザー設定：モード更新
+    Route::put('user/mode', [AuthController::class, 'updateMode']);
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ユーザーモード設定機能を追加。sweetおよびspicyの2つのモードから選択可能に。
  * ユーザーが選択したモード設定がサーバーに保存されるようになりました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/038bkn/mofumofu/pull/88?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->