### PR TITLE
矢印の変更　

### DIFF
--- a/resources/views/task_detail.blade.php
+++ b/resources/views/task_detail.blade.php
@@ -25,7 +25,7 @@
     <div class="w-full h-screen flex flex-col bg-slate-50 overflow-hidden">
         {{-- ヘッダー --}}
         <div class="flex items-center justify-between px-5 py-4 bg-white border-b border-slate-100 flex-shrink-0">
-            <a href="/day-schedule?date={{ $taskDate }}" class="text-xl p-2 -ml-2 text-slate-400">←</a>
+        <a href="#" class="text-xl p-2 -ml-2 text-slate-400" onclick="history.back(); return false;">←</a>
             <span class="font-bold text-lg text-slate-700">タスク詳細</span>
             <div class="w-8"></div>
         </div>


### PR DESCRIPTION
onclick="history.back(); return false;"　に変更しても解いた画面に戻れるようにした

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * タスク詳細画面の「戻る」ボタン動作を改善しました。ブラウザの履歴機能を使用した戻り動作に変更されました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/038bkn/mofumofu/pull/105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->