### PR TITLE
fix: ホーム画面の取得ポイント参照先をDBに変更

### DIFF
--- a/public/js/shop.js
+++ b/public/js/shop.js
@@ -77,6 +77,7 @@ document.addEventListener('DOMContentLoaded', function () {
             const data = await res.json();
             const pts  = data.points ?? data.point ?? data.score ?? 0;
             document.getElementById('userPoints').textContent = pts;
+            localStorage.setItem('total_points', pts);
         } catch (e) {
             document.getElementById('userPoints').textContent = '-';
         }
@@ -181,7 +182,9 @@ document.addEventListener('DOMContentLoaded', function () {
 
             if (res.ok) {
                 if (data.data?.total_points !== undefined) {
-                    document.getElementById('userPoints').textContent = data.data.total_points;
+                    const newPoints = data.data.total_points;
+                    document.getElementById('userPoints').textContent = newPoints;
+                    localStorage.setItem('total_points', newPoints);
                 } else {
                     await loadUserPoints();
                 }

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -359,12 +359,24 @@
 
     <script>
 
-        function updatePoints() {
+        async function updatePoints() {
 
-            const points = localStorage.getItem('total_points') || '0';
+            try {
+                const res = await fetch('/api/user', {
+                    headers: { 'Accept': 'application/json' }
+                });
+                const data = await res.json();
+                const points = data.points ?? 0;
 
-            document.querySelectorAll('.total-points-display')
-                .forEach(el => el.textContent = points);
+                document.querySelectorAll('.total-points-display')
+                    .forEach(el => el.textContent = points);
+
+                localStorage.setItem('total_points', points);
+            } catch (e) {
+                const points = localStorage.getItem('total_points') || '0';
+                document.querySelectorAll('.total-points-display')
+                    .forEach(el => el.textContent = points);
+            }
         }
 
         document.addEventListener('DOMContentLoaded', updatePoints);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **改善**
  * ポイント表示の同期機能を強化しました。サーバーからの正確なポイント情報取得に対応します。
  * ローカルストレージへのポイント情報保存機能を実装しました。通信障害時もポイント表示が維持されます。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/038bkn/mofumofu/pull/108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->