### PR TITLE
タスク詳細・カレンダー周辺のバグ修正とUI改善

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 
 class AuthController extends Controller
 {
@@ -85,6 +86,36 @@ class AuthController extends Controller
             'status' => 'success',
             'points' => $user->points,
         ]);
+    }
+
+    /**
+     * メールアドレス・パスワード更新処理
+     * PUT /api/user/credentials
+     */
+    public function updateCredentials(Request $request): JsonResponse
+    {
+        $user = Auth::user();
+
+        $request->validate([
+            'email'    => ['required', 'email', 'max:255', Rule::unique('users', 'email')->ignore($user->id)],
+            'password' => ['nullable', 'string', 'min:6', 'confirmed'],
+        ], [
+            'email.unique'    => 'このメールアドレスはすでに登録されています。',
+            'email.required'  => 'メールアドレスを入力してください。',
+            'email.email'     => '有効なメールアドレスを入力してください。',
+            'password.min'    => 'パスワードは6文字以上で入力してください。',
+            'password.confirmed' => 'パスワードが一致しません。',
+        ]);
+
+        $data = ['email' => $request->email];
+
+        if ($request->filled('password')) {
+            $data['password'] = $request->password;
+        }
+
+        $user->update($data);
+
+        return response()->json(['status' => 'success']);
     }
 
     /**

--- a/public/js/calendar.js
+++ b/public/js/calendar.js
@@ -121,26 +121,30 @@ async function updateTaskStatus(task) {
             renderCalendar(); // カレンダー画面の更新
             // ----------------
         } else {
-            alert('更新に失敗しました。');
+            showToast('更新に失敗しました。', 'error');
         }
     } catch (e) {
-        alert('ネットワークエラーが発生しました。');
+        showToast('ネットワークエラーが発生しました。', 'error');
     }
 }
 
 function renderCompletedList(tasks) {
     const container = document.getElementById('completedList');
     container.innerHTML = tasks.length === 0 ? '<p class="text-sm text-slate-400">完了済みはありません</p>' : '';
-    
+
     tasks.forEach(task => {
         const item = document.createElement('div');
-        item.className = 'rounded-2xl bg-white border border-slate-200 p-3 flex items-center justify-between opacity-60 mb-2';
+        item.className = 'rounded-2xl bg-white border border-slate-200 p-3 flex items-center justify-between opacity-60 mb-2 cursor-pointer hover:opacity-80 transition';
         item.innerHTML = `
             <div class="flex items-center gap-2 truncate">
                 <span class="text-emerald-500 font-bold">✓</span>
                 <span class="text-sm text-slate-400 line-through">${task.title}</span>
             </div>
+            <span class="text-xs text-slate-400 ml-2 flex-shrink-0">${task.due_date.split('-').slice(1).join('/')}</span>
         `;
+        item.addEventListener('click', () => {
+            window.location.href = `/task/detail?id=${task.id}&date=${task.due_date}`;
+        });
         container.appendChild(item);
     });
 }

--- a/public/js/calendar.js
+++ b/public/js/calendar.js
@@ -61,19 +61,26 @@ async function loadMonthTasks(year, month) {
 function renderTodoList(tasks) {
     const container = document.getElementById('todoList');
     container.innerHTML = tasks.length === 0 ? '<div class="p-3 text-slate-400">予定がありません</div>' : '';
-    
+
+    const today = new Date().toISOString().split('T')[0];
+
     tasks.forEach(task => {
+        const isOverdue = task.due_date < today;
         const item = document.createElement('div');
-        item.className = 'rounded-2xl bg-slate-50 border border-slate-200 p-3 flex items-center justify-between mb-2 shadow-sm';
+        item.className = isOverdue
+            ? 'rounded-2xl bg-rose-50 border border-rose-200 p-3 flex items-center justify-between mb-2 shadow-sm'
+            : 'rounded-2xl bg-slate-50 border border-slate-200 p-3 flex items-center justify-between mb-2 shadow-sm';
         item.innerHTML = `
             <div class="flex items-center gap-3 flex-1 min-w-0">
                 <input type="checkbox" class="w-6 h-6 rounded border-slate-300 text-rose-500 task-check cursor-pointer">
                 <div class="flex flex-col flex-1 min-w-0 cursor-pointer task-link">
-                    <span class="text-sm font-bold text-slate-800 truncate">${task.title}</span>
-                    <span class="text-[10px] text-amber-500 font-bold">★${task.difficulty || 1}</span>
+                    <span class="text-sm font-bold ${isOverdue ? 'text-rose-600' : 'text-slate-800'} truncate">${task.title}</span>
+                    <span class="text-[10px] ${isOverdue ? 'text-rose-400' : 'text-amber-500'} font-bold">
+                        ${isOverdue ? '期日切れ · ' : ''}★${task.difficulty || 1}
+                    </span>
                 </div>
             </div>
-            <span class="text-xs text-slate-400 ml-2">${task.due_date.split('-').slice(1).join('/')}</span>
+            <span class="text-xs ${isOverdue ? 'text-rose-400' : 'text-slate-400'} ml-2">${task.due_date.split('-').slice(1).join('/')}</span>
         `;
         
         // チェックボックスで更新

--- a/public/js/day_schedule.js
+++ b/public/js/day_schedule.js
@@ -98,6 +98,12 @@ document.addEventListener('DOMContentLoaded', async () => {
                 const isDone =
                     Number(task.status) === 1;
 
+                const today =
+                    new Date().toISOString().split('T')[0];
+
+                const isOverdue =
+                    !isDone && date < today;
+
                 const eventBox =
                     document.createElement('div');
 
@@ -109,7 +115,9 @@ document.addEventListener('DOMContentLoaded', async () => {
                     overflow-hidden
                     ${isDone
                         ? 'bg-slate-400 opacity-70'
-                        : 'bg-slate-800'}
+                        : isOverdue
+                            ? 'bg-rose-400'
+                            : 'bg-slate-800'}
                 `;
 
                 eventBox.style.top =
@@ -126,6 +134,9 @@ document.addEventListener('DOMContentLoaded', async () => {
                             ? 'line-through'
                             : ''}">
                         ${task.title}
+                        ${isOverdue
+                            ? '<span style="font-size:9px;opacity:0.9;margin-left:4px;">期日切れ</span>'
+                            : ''}
                     </div>
 
                     <div class="text-[10px]

--- a/public/js/detail.js
+++ b/public/js/detail.js
@@ -41,6 +41,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
 
         const formattedDate = currentTask.due_date.replace(/-/g, '/');
+        const isDone = Number(currentTask.status) === 1;
 
         contentArea.innerHTML = `
             <div class="text-center">
@@ -67,8 +68,19 @@ document.addEventListener('DOMContentLoaded', async () => {
                         ${currentTask.note || 'メモはありません'}
                     </p>
                 </div>
+
+                <button id="toggleStatusBtn"
+                    class="w-full mt-6 font-bold py-3 rounded-full
+                        ${isDone
+                            ? 'bg-slate-200 text-slate-600'
+                            : 'bg-green-400 text-white'}">
+                    ${isDone ? '未完了に戻す' : '完了にする'}
+                </button>
             </div>
         `;
+
+        document.getElementById('toggleStatusBtn')
+            .addEventListener('click', toggleStatus);
 
         editBtn.textContent = '編集する';
     }
@@ -87,12 +99,12 @@ document.addEventListener('DOMContentLoaded', async () => {
                     <input id="editStart"
                         type="time"
                         class="flex-1 border rounded-xl p-3"
-                        value="${currentTask.start_time || ''}">
+                        value="${currentTask.start_time ? currentTask.start_time.substring(0,5) : ''}">
 
                     <input id="editEnd"
                         type="time"
                         class="flex-1 border rounded-xl p-3"
-                        value="${currentTask.end_time || ''}">
+                        value="${currentTask.end_time ? currentTask.end_time.substring(0,5) : ''}">
                 </div>
 
                 <input id="editLocation"
@@ -117,13 +129,44 @@ document.addEventListener('DOMContentLoaded', async () => {
             .addEventListener('click', saveTask);
     }
 
+    async function toggleStatus() {
+        const newStatus = Number(currentTask.status) === 1 ? 0 : 1;
+
+        try {
+            const response = await fetch(`/api/tasks/${taskId}`, {
+                method: 'PUT',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-TOKEN':
+                        document.querySelector('meta[name="csrf-token"]').content,
+                    'Accept': 'application/json'
+                },
+                body: JSON.stringify({ status: newStatus })
+            });
+
+            const json = await response.json();
+
+            if (response.ok) {
+                currentTask = { ...currentTask, status: newStatus };
+                if (newStatus === 1 && json.earned_points) {
+                    showToast(`完了！ +${json.earned_points}pt 獲得`, 'success');
+                }
+                renderViewMode();
+            } else {
+                showToast('ステータスの変更に失敗しました', 'error');
+            }
+        } catch {
+            showToast('通信エラーが発生しました', 'error');
+        }
+    }
+
     async function saveTask() {
         const data = {
             title: document.getElementById('editTitle').value,
-            start_time: document.getElementById('editStart').value,
-            end_time: document.getElementById('editEnd').value,
-            location: document.getElementById('editLocation').value,
-            note: document.getElementById('editNote').value
+            start_time: document.getElementById('editStart').value || null,
+            end_time: document.getElementById('editEnd').value || null,
+            location: document.getElementById('editLocation').value || null,
+            note: document.getElementById('editNote').value || null
         };
 
         try {
@@ -144,12 +187,12 @@ document.addEventListener('DOMContentLoaded', async () => {
                     ...data
                 };
                 renderViewMode();
-                alert('保存しました');
+                showToast('保存しました', 'success');
             } else {
-                alert('保存に失敗しました');
+                showToast('保存に失敗しました', 'error');
             }
         } catch {
-            alert('通信エラーが発生しました');
+            showToast('通信エラーが発生しました', 'error');
         }
     }
 
@@ -161,28 +204,28 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
     });
 
-    deleteBtn.addEventListener('click', async () => {
-        if (!confirm('この予定を削除しますか？')) return;
+    deleteBtn.addEventListener('click', () => {
+        showConfirm('この予定を削除しますか？', async () => {
+            try {
+                const response = await fetch(`/api/tasks/${taskId}`, {
+                    method: 'DELETE',
+                    headers: {
+                        'X-CSRF-TOKEN':
+                            document.querySelector('meta[name="csrf-token"]').content,
+                        'Accept': 'application/json'
+                    }
+                });
 
-        try {
-            const response = await fetch(`/api/tasks/${taskId}`, {
-                method: 'DELETE',
-                headers: {
-                    'X-CSRF-TOKEN':
-                        document.querySelector('meta[name="csrf-token"]').content,
-                    'Accept': 'application/json'
+                if (response.ok) {
+                    window.location.href =
+                        `/day-schedule?date=${scheduleDate}`;
+                } else {
+                    showToast('削除に失敗しました', 'error');
                 }
-            });
-
-            if (response.ok) {
-                window.location.href =
-                    `/day-schedule?date=${scheduleDate}`;
-            } else {
-                alert('削除に失敗しました');
+            } catch {
+                showToast('通信エラーが発生しました', 'error');
             }
-        } catch {
-            alert('通信エラーが発生しました');
-        }
+        });
     });
 
     loadTask();

--- a/public/js/pass.js
+++ b/public/js/pass.js
@@ -10,14 +10,14 @@ function hideError() {
     el.style.display = "none";
 }
 
-function saveChanges() {
+async function saveChanges() {
     hideError();
 
     const email       = document.getElementById("emailInput").value.trim();
     const newPass     = document.getElementById("newPassword").value;
     const confirmPass = document.getElementById("confirmPassword").value;
 
-    // バリデーション
+    // フロントエンドバリデーション
     if (!email) {
         showError("メールアドレスを入力してください");
         return;
@@ -38,28 +38,47 @@ function saveChanges() {
         return;
     }
 
-    // Laravelへ送信
-    const form = document.createElement("form");
-    form.method = "POST";
-    form.action = "/pass/update";
+    try {
+        const response = await fetch('/api/user/credentials', {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
+            },
+            body: JSON.stringify({
+                email:                 email,
+                password:              newPass,
+                password_confirmation: confirmPass,
+            }),
+        });
 
-    const fields = {
-        "_token":                    document.querySelector('meta[name="csrf-token"]').content,
-        "email":                     email,
-        "new_password":              newPass,
-        "new_password_confirmation": confirmPass,
-    };
+        const data = await response.json();
 
-    Object.entries(fields).forEach(([name, value]) => {
-        const input = document.createElement("input");
-        input.type  = "hidden";
-        input.name  = name;
-        input.value = value;
-        form.appendChild(input);
-    });
+        if (response.ok && data.status === 'success') {
+            localStorage.setItem('email', email);
+            location.href = '/user';
+            return;
+        }
 
-    document.body.appendChild(form);
-    form.submit();
+        // バリデーションエラー (422)
+        if (response.status === 422 && data.errors) {
+            const errors = data.errors;
+            if (errors.email) {
+                showError(errors.email[0]);
+            } else if (errors.password) {
+                showError(errors.password[0]);
+            } else {
+                showError('入力内容を確認してください。');
+            }
+            return;
+        }
+
+        showError('保存に失敗しました。もう一度お試しください。');
+
+    } catch (err) {
+        console.error(err);
+        showError('通信エラーが発生しました。もう一度お試しください。');
+    }
 }
 
 // 初期ロード

--- a/public/js/task_create.js
+++ b/public/js/task_create.js
@@ -36,15 +36,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
         // フロント側バリデーション
         if (!title) {
-            alert('タイトルを入力してください。');
+            showToast('タイトルを入力してください。', 'error');
             return;
         }
         if (!difficulty) {
-            alert('難易度を選択してください。');
+            showToast('難易度を選択してください。', 'error');
             return;
         }
         if (start && end && start >= end) {
-            alert('終了時刻は開始時刻より後にしてください。');
+            showToast('終了時刻は開始時刻より後にしてください。', 'error');
             return;
         }
 
@@ -79,9 +79,9 @@ document.addEventListener('DOMContentLoaded', () => {
                 return;
             }
 
-            alert(json.message || 'タスクの登録に失敗しました。');
+            showToast(json.message || 'タスクの登録に失敗しました。', 'error');
         } catch (e) {
-            alert('通信エラーが発生しました。もう一度お試しください。');
+            showToast('通信エラーが発生しました。もう一度お試しください。', 'error');
         } finally {
             if (saveBtn) saveBtn.disabled = false;
         }

--- a/public/js/toast.js
+++ b/public/js/toast.js
@@ -1,0 +1,161 @@
+(function () {
+    const style = document.createElement('style');
+    style.textContent = `
+        #_toast {
+            position: fixed;
+            top: 24px;
+            left: 50%;
+            transform: translateX(-50%) translateY(-12px);
+            padding: 12px 28px;
+            border-radius: 9999px;
+            font-weight: 700;
+            font-size: 14px;
+            box-shadow: 0 4px 20px rgba(0,0,0,0.15);
+            z-index: 9999;
+            opacity: 0;
+            transition: opacity 0.25s ease, transform 0.25s ease;
+            pointer-events: none;
+            white-space: nowrap;
+            max-width: calc(100vw - 48px);
+            text-align: center;
+            font-family: 'Hiragino Sans', 'Noto Sans JP', sans-serif;
+        }
+        #_toast.visible {
+            opacity: 1;
+            transform: translateX(-50%) translateY(0);
+        }
+        #_toast.success { background: #4ade80; color: #fff; }
+        #_toast.error   { background: #f87171; color: #fff; }
+        #_toast.info    { background: #334155; color: #fff; }
+
+        #_confirm_overlay {
+            position: fixed;
+            inset: 0;
+            background: rgba(0,0,0,0.35);
+            z-index: 10000;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            opacity: 0;
+            transition: opacity 0.2s ease;
+        }
+        #_confirm_overlay.visible { opacity: 1; }
+        #_confirm_box {
+            background: #fff;
+            border-radius: 24px;
+            padding: 28px 24px 20px;
+            width: calc(100vw - 64px);
+            max-width: 320px;
+            text-align: center;
+            box-shadow: 0 8px 32px rgba(0,0,0,0.18);
+            transform: translateY(12px);
+            transition: transform 0.2s ease;
+            font-family: 'Hiragino Sans', 'Noto Sans JP', sans-serif;
+        }
+        #_confirm_overlay.visible #_confirm_box { transform: translateY(0); }
+        #_confirm_msg {
+            font-weight: 700;
+            font-size: 16px;
+            color: #1e293b;
+            margin-bottom: 20px;
+        }
+        #_confirm_btns {
+            display: flex;
+            gap: 10px;
+        }
+        #_confirm_cancel {
+            flex: 1;
+            padding: 12px;
+            border-radius: 9999px;
+            border: 1.5px solid #e2e8f0;
+            background: #fff;
+            font-weight: 700;
+            font-size: 14px;
+            color: #64748b;
+            cursor: pointer;
+        }
+        #_confirm_ok {
+            flex: 1;
+            padding: 12px;
+            border-radius: 9999px;
+            border: none;
+            background: #f87171;
+            font-weight: 700;
+            font-size: 14px;
+            color: #fff;
+            cursor: pointer;
+        }
+    `;
+    document.head.appendChild(style);
+
+    let timer = null;
+
+    window.showToast = function (message, type) {
+        type = type || 'info';
+
+        const existing = document.getElementById('_toast');
+        if (existing) {
+            clearTimeout(timer);
+            existing.remove();
+        }
+
+        const toast = document.createElement('div');
+        toast.id = '_toast';
+        toast.className = type;
+        toast.textContent = message;
+        document.body.appendChild(toast);
+
+        requestAnimationFrame(function () {
+            requestAnimationFrame(function () {
+                toast.classList.add('visible');
+            });
+        });
+
+        timer = setTimeout(function () {
+            toast.classList.remove('visible');
+            setTimeout(function () {
+                if (toast.parentNode) toast.remove();
+            }, 300);
+        }, 3000);
+    };
+
+    window.showConfirm = function (message, onOk, okLabel, cancelLabel) {
+        okLabel     = okLabel     || '削除する';
+        cancelLabel = cancelLabel || 'キャンセル';
+
+        const overlay = document.createElement('div');
+        overlay.id = '_confirm_overlay';
+        overlay.innerHTML = `
+            <div id="_confirm_box">
+                <p id="_confirm_msg">${message}</p>
+                <div id="_confirm_btns">
+                    <button id="_confirm_cancel">${cancelLabel}</button>
+                    <button id="_confirm_ok">${okLabel}</button>
+                </div>
+            </div>
+        `;
+        document.body.appendChild(overlay);
+
+        requestAnimationFrame(function () {
+            requestAnimationFrame(function () {
+                overlay.classList.add('visible');
+            });
+        });
+
+        function close() {
+            overlay.classList.remove('visible');
+            setTimeout(function () {
+                if (overlay.parentNode) overlay.remove();
+            }, 200);
+        }
+
+        overlay.querySelector('#_confirm_cancel').addEventListener('click', close);
+        overlay.querySelector('#_confirm_ok').addEventListener('click', function () {
+            close();
+            onOk();
+        });
+        overlay.addEventListener('click', function (e) {
+            if (e.target === overlay) close();
+        });
+    };
+}());

--- a/public/js/user.js
+++ b/public/js/user.js
@@ -41,7 +41,7 @@ function saveName() {
     const name = input.value.trim();
 
     if (!name) {
-        alert("ユーザー名を入力してください");
+        showToast('ユーザー名を入力してください', 'error');
         return;
     }
 
@@ -76,16 +76,13 @@ async function executeLogout() {
 
         // 未ログイン
         if (response.status === 401) {
-
-            alert('ログインしていません');
-
+            showToast('ログインしていません', 'error');
             return;
         }
 
         // 成功
-        alert('ログアウトしました');
-
-        location.href = '/login';
+        showToast('ログアウトしました', 'success');
+        setTimeout(() => { location.href = '/login'; }, 1000);
 
     } catch (error) {
 

--- a/resources/views/calendar_screen.blade.php
+++ b/resources/views/calendar_screen.blade.php
@@ -198,6 +198,7 @@
 
 </div>
 
+<script src="{{ asset('js/toast.js') }}"></script>
 <script src="{{ asset('js/calendar.js') }}"></script>
 
 </body>

--- a/resources/views/setting.blade.php
+++ b/resources/views/setting.blade.php
@@ -162,8 +162,8 @@
                 </button>
             </div>
         </div>
-        <!-- モード -->
-        <div class="setting-section">
+        {{-- モード（実装保留中のためコメントアウト） --}}
+        {{-- <div class="setting-section">
             <div class="field-label">
                 モード選択
             </div>
@@ -202,7 +202,7 @@
 
                 </button>
             </div>
-        </div>
+        </div> --}}
         <!-- フォント -->
         <div class="setting-section">
             <label

--- a/resources/views/task_create.blade.php
+++ b/resources/views/task_create.blade.php
@@ -51,7 +51,7 @@
             </div>
 
             {{-- メインコンテンツ --}}
-            <div class="flex-1 overflow-y-auto px-5 py-6">
+            <div class="flex-1 overflow-y-auto px-5 py-6 pb-24">
                 <input type="hidden" id="taskDate" value="{{ $taskDate }}">
                 
                 {{-- タイトル --}}
@@ -94,12 +94,20 @@
         </form>
 
         {{-- ボトムナビ --}}
-        <nav class="w-full flex justify-center items-center text-slate-600 flex-shrink-0 border-t border-[#9ecfde]" style="background-color: #b8e0e9; height: 80px;">
-            <div class="w-full max-w-2xl px-6 flex justify-between items-center">
-                <a href="/chat" class="flex flex-col items-center gap-1"><span>💬</span><span class="text-[10px] font-bold">ひとりごと</span></a>
-                <a href="/home" class="flex flex-col items-center gap-1"><span>🏠</span><span class="text-[10px] font-bold">ホーム</span></a>
-                <a href="/calendar" class="flex flex-col items-center gap-1 text-slate-900"><span>🗓️</span><span class="text-[10px] font-bold border-b-2 border-slate-900">ToDo</span></a>
-                <a href="/setting" class="flex flex-col items-center gap-1"><span>⚙️</span><span class="text-[10px] font-bold">設定</span></a>
+        <nav class="fixed bottom-0 left-0 w-full h-[68px] bg-[#cdeef9] border-t border-[#b5d9e4] z-20">
+            <div class="w-full max-w-[390px] mx-auto h-full flex justify-around items-center">
+                <a href="/chat" class="flex flex-col items-center justify-center">
+                    <img src="{{ asset('images/icon/chat.png') }}" class="w-16 h-16 object-contain">
+                </a>
+                <a href="/home" class="flex flex-col items-center justify-center">
+                    <img src="{{ asset('images/icon/home.png') }}" class="w-16 h-16 object-contain">
+                </a>
+                <a href="/calendar" class="flex flex-col items-center justify-center">
+                    <img src="{{ asset('images/icon/todo.png') }}" class="w-16 h-16 object-contain">
+                </a>
+                <a href="/setting" class="flex flex-col items-center justify-center">
+                    <img src="{{ asset('images/icon/setting.png') }}" class="w-16 h-16 object-contain">
+                </a>
             </div>
         </nav>
     </div>

--- a/resources/views/task_create.blade.php
+++ b/resources/views/task_create.blade.php
@@ -104,6 +104,7 @@
         </nav>
     </div>
 
+    <script src="{{ asset('js/toast.js') }}"></script>
     <script src="{{ asset('js/task_create.js') }}"></script>
 </body>
 </html>

--- a/resources/views/task_detail.blade.php
+++ b/resources/views/task_detail.blade.php
@@ -31,7 +31,7 @@
         </div>
 
         {{-- メインコンテンツ --}}
-        <div class="flex-1 overflow-y-auto px-6 py-8">
+        <div class="flex-1 overflow-y-auto px-6 pt-8 pb-24">
             {{-- IDを detail.js と一致させています --}}
             <div id="taskContent" class="space-y-6">
                 <p class="text-center text-slate-400">読み込み中...</p>
@@ -73,6 +73,7 @@
         window.taskId = "{{ $taskId }}";
         window.scheduleDate = "{{ $taskDate }}";
     </script>
-    <script src="{{ asset('js/detail.js') }}"></script>
+    <script src="{{ asset('js/toast.js') }}?v={{ filemtime(public_path('js/toast.js')) }}"></script>
+    <script src="{{ asset('js/detail.js') }}?v={{ filemtime(public_path('js/detail.js')) }}"></script>
 </body>
 </html>

--- a/resources/views/user.blade.php
+++ b/resources/views/user.blade.php
@@ -140,6 +140,7 @@
         </div>
     </div>
 
+    <script src="{{ asset('js/toast.js') }}"></script>
     <script src="{{ asset('js/user.js') }}"></script>
 </body>
 </html>

--- a/routes/api.php
+++ b/routes/api.php
@@ -32,6 +32,9 @@ Route::middleware(['web', 'auth'])->group(function () {
     // ユーザー情報取得
     Route::get('user', [AuthController::class, 'show']);
 
+    // ユーザー設定：メールアドレス・パスワード更新
+    Route::put('user/credentials', [AuthController::class, 'updateCredentials']);
+
     // ユーザー設定：モード更新
     Route::put('user/mode', [AuthController::class, 'updateMode']);
 });


### PR DESCRIPTION
バグ修正
タスク編集で部分変更が失敗する問題 (detail.js)

saveTask() で start_time / end_time / location / note が空のとき "" 空文字列をそのままAPIに送っており、date_format:H:i バリデーションエラーになっていた
|| null で空文字列を null に変換することで修正
時間フィールドの初期値も .substring(0, 5) で HH:MM 形式に正規化（DBから HH:MM:SS で来るケースに対応）
削除ボタン・編集ボタンがナビバーに隠れる問題 (task_detail.blade.php, task_create.blade.php)

固定ナビバー（68px）の高さ分、スクロール領域の下端が切れていた
pb-24 を追加してコンテンツがナビバーの下に隠れないよう対応
機能追加
タスクのステータス切り替えUI (detail.js)

詳細画面に「完了にする」/ 「未完了に戻す」ボタンを追加
完了時はポイント獲得をトーストで通知
ネイティブ alert / confirm をカスタムUIに統一 (toast.js 新規作成)

ブラウザのネイティブダイアログをすべて廃止
showToast(message, type): 画面上部にフワッと出て3秒で自動消えるトースト通知（success / error / info）
showConfirm(message, onOk): 削除確認などに使うカスタムモーダル（背景タップでキャンセル可）
対象ファイル: detail.js / task_create.js / calendar.js / user.js
ログアウト時はトーストを1秒表示してからリダイレクト
期日切れタスクのスタイル差別化 (calendar.js, day_schedule.js)

ステータス0（未完了）かつ期日が過去日付のタスクを視覚的に区別
カレンダーリスト: ピンク背景・赤ボーダー・「期日切れ」ラベル
デイスケジュール: bg-rose-400（赤）＋「期日切れ」ラベル
完了済みタスクを詳細・編集可能に (calendar.js)

カレンダーの「完了済み」リストのアイテムをタップすると詳細ページへ遷移するよう変更
詳細ページで「未完了に戻す」も可能
タスク登録画面のフッターをホームと統一 (task_create.blade.php)

絵文字ベースのフッターをホーム画面と同じアイコン画像・配色（bg-[#cdeef9]）に変更